### PR TITLE
Introduce terms at the right time, fix #5

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,20 +1,24 @@
 # Introduction to Bianca: Handling Sensitive Research Data
 
-Are you working with your sensitive data in your research? If yes, welcome to a full day introduction to handling sensitive data on the UPPMAX cluster, Bianca. If yes, welcome to a full day introduction to handling sensitive data on the UPPMAX cluster, Bianca. We will tell you about NAISS-SENS, how to login to Bianca, transfer files via wharf, basics on the SLURM workload manager and the module system.
+Are you starting to work with your sensitive data in your research? 
 
-Tentative schedule
+If yes, welcome to a full day introduction to handling sensitive data on the UPPMAX cluster, Bianca!
+
+You will learn about the national infrastructure Bianca is part of, how to login to Bianca, upload and download files, using pre-installed software and how to start your code.
+
+Tentative schedule:
 
     9.00 Introduction
-    9.15 Intro to NAISS-Sens
-    9.35 Login: Thinlinc
+    9.15 NAISS-Sens
+    9.35 Login using Thinlinc
     9.55 coffee break
     10.10 Command line intro specific to Bianca
     10.55 break
     11.10 Module system
-    12.00 LUNCH
-    13.00 Intro to transfering files to and from Bianca
+    12.00 Lunch
+    13.00 Intro to transferring files to and from Bianca
     13.55 break
-    14.10 Compute nodes and slurm
+    14.10 Compute nodes and SLURM
     14.55 Coffee break
     15.10 Summary
     15.15 Q/A


### PR DESCRIPTION
The learner-to-be has to learn about some new terms. For example. 'the module system' is needed to 'run pre-installed' software. I feel at an introduction page, we should write with the known (lack of) knowledge of a learner that has not yet taken the course.

In the schedule, I think it is fine to use the technical terms.

What do you think?